### PR TITLE
Fix EXDEV error on self-hosted runners with separate /tmp filesystem

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,8 @@ export async function run(): Promise<void> {
     await io.mkdirP(execFolder)
     const exec = `trunk${ext}`
     const execPath = path.join(execFolder, exec)
-    await io.mv(path.join(extractedFolder, exec), execPath)
+    await io.cp(path.join(extractedFolder, exec), execPath)
+    await io.rmRF(path.join(extractedFolder, exec))
     core.info(`Installed trunk to ${execPath} 🎉`)
   } catch (error) {
     // Fail the workflow run if an error occurs


### PR DESCRIPTION
I got "EXDEV: cross-device link not permitted" error that occurs when using trunk-action on self-hosted runners where `/tmp` and `/home` are on different filesystems.

<img width="1359" height="272" alt="image" src="https://github.com/user-attachments/assets/dc4df7fb-5bc9-4de8-840f-b332308cdd6f" />


  The current implementation uses `io.mv()` to move the trunk binary from the temporary
  extraction folder to `~/.cargo/bin`. This fails with an EXDEV error when these directories
  are on different filesystems, which is common on self-hosted runners where `/tmp` is often
  mounted as tmpfs (RAM-based filesystem).

  ## Solution
  Replace the `io.mv()` operation with:
  1. `io.cp()` - Copy the file to the destination
  2. `io.rmRF()` - Remove the source file

  This achieves the same result as a move operation but works across filesystem boundaries.